### PR TITLE
Fix to allow configuration through Spring using Groovy or XML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,13 +82,6 @@
             <url>http://tony19.github.com</url>
             <timezone>-5</timezone>
         </developer>
-        <developer>
-            <id>kaxelson</id>
-            <name>Knute Axelson</name>
-            <email>kaxelson@gmail.com</email>
-            <url>https://github.com/kaxelson</url>
-            <timezone>-6</timezone>
-        </developer>
     </developers>
 
     <modules>


### PR DESCRIPTION
Made a change to LogbackConfigurer to fix a NPE resulting from a null ContextSelector and to allow configuration using Groovy or XML.  Also changed parent pom so that developers using eclipse m2e would not have errors after importing the project into the IDE.
