### PR TITLE
Incorrect brige of log messages in JUL to SLF4J projects

### DIFF
--- a/spring/src/main/java/ch/qos/logback/ext/spring/web/WebLogbackConfigurer.java
+++ b/spring/src/main/java/ch/qos/logback/ext/spring/web/WebLogbackConfigurer.java
@@ -151,6 +151,13 @@ public class WebLogbackConfigurer {
         //from the Java Logging framework into SLF4J. When logging is terminated, the bridge will need to be uninstalled
         try {
             Class<?> julBridge = ClassUtils.forName("org.slf4j.bridge.SLF4JBridgeHandler", ClassUtils.getDefaultClassLoader());
+            
+            Method removeHandlers = ReflectionUtils.findMethod(julBridge, "removeHandlersForRootLogger");
+            if (removeHandlers != null) {
+                servletContext.log("Removing all previous handlers for JUL to SLF4J bridge");
+                ReflectionUtils.invokeMethod(removeHandlers, null);
+            }
+            
             Method install = ReflectionUtils.findMethod(julBridge, "install");
             if (install != null) {
                 servletContext.log("Installing JUL to SLF4J bridge");


### PR DESCRIPTION
We have detected that logging from JUL to SLF4J is not working properly in Jersey JAX-RS implementation as described in this reference:

http://blog.cn-consult.dk/2009/03/bridging-javautillogging-to-slf4j.html

Modified init method in order to remove all previous handlers before installing the JUL to SLF4J one.
