### PR TITLE
Updated LogglyBatchAppender to use correct endpoint URL path by default

### DIFF
--- a/loggly/src/main/java/ch/qos/logback/ext/loggly/AbstractLogglyAppender.java
+++ b/loggly/src/main/java/ch/qos/logback/ext/loggly/AbstractLogglyAppender.java
@@ -131,14 +131,21 @@ public abstract class AbstractLogglyAppender<E> extends UnsynchronizedAppenderBa
     }
 
     protected String buildEndpointUrl(String inputKey) {
-        return new StringBuilder(DEFAULT_ENDPOINT_PREFIX).append(getEndpointPath())
-        		.append(inputKey).toString();
+        return new StringBuilder(DEFAULT_ENDPOINT_PREFIX).append(getEndpointPrefix())
+                .append(inputKey).toString();
     }
     
     /**
-     * The standard HTTP endpoint uses a different URL path than the bulk HTTP endpoint
+     * Returns the URL path prefix for the Loggly endpoint to which the 
+     * implementing class will send log events. This path prefix varies
+     * for the different Loggly services. The final endpoint URL is built
+     * by concatenating the {@link #DEFAULT_ENDPOINT_PREFIX} with the
+     * endpoint prefix from {@link #getEndpointPrefix()} and the 
+     * {@link #inputKey}.
+     *
+     * @return the URL path prefix for the Loggly endpoint
      */
-    protected abstract String getEndpointPath();
+    protected abstract String getEndpointPrefix();
 
     public String getEndpointUrl() {
         return endpointUrl;

--- a/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyAppender.java
+++ b/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyAppender.java
@@ -29,8 +29,8 @@ import java.net.URL;
  */
 public class LogglyAppender<E> extends AbstractLogglyAppender<E> {
 
-	public static final String ENDPOINT_URL_PATH = "inputs/";
-	
+    public static final String ENDPOINT_URL_PATH = "inputs/";
+    
     public LogglyAppender() {
     }
 
@@ -74,9 +74,9 @@ public class LogglyAppender<E> extends AbstractLogglyAppender<E> {
         }
     }
 
-	@Override
-	protected String getEndpointPath() {
-		return ENDPOINT_URL_PATH;
-	}
+    @Override
+    protected String getEndpointPrefix() {
+        return ENDPOINT_URL_PATH;
+    }
 }
 

--- a/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyBatchAppender.java
+++ b/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyBatchAppender.java
@@ -144,8 +144,8 @@ import ch.qos.logback.ext.loggly.io.IoUtils;
  */
 public class LogglyBatchAppender<E> extends AbstractLogglyAppender<E> implements LogglyBatchAppenderMBean {
 
-	public static final String ENDPOINT_URL_PATH = "bulk/";
-	
+    public static final String ENDPOINT_URL_PATH = "bulk/";
+    
     private boolean debug = false;
 
     private int flushIntervalInSeconds = 3;
@@ -452,8 +452,8 @@ public class LogglyBatchAppender<E> extends AbstractLogglyAppender<E> implements
         }
     }
 
-	@Override
-	protected String getEndpointPath() {
-		return ENDPOINT_URL_PATH;
-	}
+    @Override
+    protected String getEndpointPrefix() {
+        return ENDPOINT_URL_PATH;
+    }
 }


### PR DESCRIPTION
implementing classes must provide: getEndpointPath() that returns the
URL path for the Loggly service (inputs/ for the standard HTTP/S service
and bulk/ for the bulk HTTP/S service).

This prevents the user from needing to manually override the endpoint
URL for the LogglyBatchAppender in order to take advantage of the bulk
logging API (where a single HTTP request can contain multiple log
events, which will be parsed out accordingly).
