### PR TITLE
loggly: Add header support for tags

### DIFF
--- a/loggly/src/main/java/ch/qos/logback/ext/loggly/AbstractLogglyAppender.java
+++ b/loggly/src/main/java/ch/qos/logback/ext/loggly/AbstractLogglyAppender.java
@@ -40,6 +40,8 @@ public abstract class AbstractLogglyAppender<E> extends UnsynchronizedAppenderBa
     protected static final Charset UTF_8 = Charset.forName("UTF-8");
     protected String endpointUrl;
     protected String inputKey;
+    private LogglyTagList tags;
+    protected String xLogglyTag;
     protected Layout<E> layout;
     protected boolean layoutCreatedImplicitly = false;
     private String pattern;
@@ -168,6 +170,29 @@ public abstract class AbstractLogglyAppender<E> extends UnsynchronizedAppenderBa
             cleaned = null;
         }
         this.inputKey = cleaned;
+    }
+    
+    public void setTags(LogglyTagList tags) {
+    	this.tags = tags;
+    	if(this.tags != null && !this.tags.isEmpty()) {
+        	StringBuilder sb = new StringBuilder();
+        	for(int i = 0; i < this.tags.size(); ++i) {
+        		if(i > 0) {
+        			sb.append(",");
+        		}
+        		sb.append(this.tags.get(i).trim());
+        	}
+        	xLogglyTag = sb.toString();
+        	if(xLogglyTag.trim().equals("")) {
+        		xLogglyTag = null;
+        	}
+        } else {
+        	xLogglyTag = null;
+        }
+    }
+    
+    public LogglyTagList getTags() {
+    	return tags;
     }
 
     public String getPattern() {

--- a/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyAppender.java
+++ b/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyAppender.java
@@ -53,6 +53,9 @@ public class LogglyAppender<E> extends AbstractLogglyAppender<E> {
             connection.setRequestMethod("POST");
             connection.setDoOutput(true);
             connection.addRequestProperty("Content-Type", this.layout.getContentType());
+            if(xLogglyTag != null) {
+            	connection.addRequestProperty("X-LOGGLY-TAG", xLogglyTag);
+            }
             connection.connect();
             sendAndClose(event, connection.getOutputStream());
             connection.disconnect();

--- a/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyTagList.java
+++ b/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyTagList.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2014 The logback-extensions developers (logback-user@qos.ch)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.ext.loggly;
+
+import java.util.ArrayList;
+
+/**
+ * Wraps a {@link java.util.ArrayList} of {@link java.lang.String}s to allow
+ * specification of a list of tags in logback.xml like so:
+ * <br /><br />
+ * &lt;appender ...&gt;<br />
+ * &nbsp;&nbsp;&lt;tags&gt;<br />
+ * &nbsp;&nbsp;&nbsp;&nbsp;&lt;tag&gt;my-app&lt;/tag&gt;<br />
+ * &nbsp;&nbsp;&nbsp;&nbsp;&lt;tag&gt;dev&lt;/tag&gt;<br />
+ * &nbsp;&nbsp;&lt;/tags&gt;<br />
+ * &lt;/appender&gt;
+ * 
+ * @author Robert Schmidtke
+ * @since 0.1
+ *
+ */
+public class LogglyTagList extends ArrayList<String> {
+	
+	private static final long serialVersionUID = -1421483678444031480L;
+
+	public void addTag(String tag) {
+		super.add(tag);
+	}
+
+}


### PR DESCRIPTION
hi there,

while I was using your loggly extension for logback I noticed it was impossible to send tags along with the request so I quickly added the feature. I'm already using it and it works fine for me. thanks for the great work.

best
robert