### PR TITLE
loggly: Allow configuring HTTP read timeout

### DIFF
--- a/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyBatchAppender.java
+++ b/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyBatchAppender.java
@@ -440,7 +440,7 @@ public class LogglyBatchAppender<E> extends AbstractLogglyAppender<E> implements
      */
     public void setConnReadTimeoutSeconds(int connReadTimeoutSeconds) {
         this.connReadTimeoutSeconds = connReadTimeoutSeconds;
-	}
+    }
 
     private String getDebugInfo() {
         return "{" +

--- a/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyBatchAppender.java
+++ b/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyBatchAppender.java
@@ -174,6 +174,9 @@ public class LogglyBatchAppender<E> extends AbstractLogglyAppender<E> implements
 
     private Charset charset = Charset.forName("UTF-8");
 
+    /* Store Connection Read Timeout */
+    private int connReadTimeoutSeconds = 1;
+
     @Override
     protected void append(E eventObject) {
         if (!isStarted()) {
@@ -334,6 +337,8 @@ public class LogglyBatchAppender<E> extends AbstractLogglyAppender<E> implements
         try {
 
             HttpURLConnection conn = getHttpConnection(new URL(endpointUrl));
+            /* Set connection Read Timeout */
+            conn.setReadTimeout(connReadTimeoutSeconds*1000);
             BufferedOutputStream out = new BufferedOutputStream(conn.getOutputStream());
 
             long len = IoUtils.copy(in, out);
@@ -430,7 +435,12 @@ public class LogglyBatchAppender<E> extends AbstractLogglyAppender<E> implements
         this.maxBucketSizeInKilobytes = maxBucketSizeInKilobytes;
     }
 
-    private String getDebugInfo() {
+    /* set method for Logback to allow Connection Read Timeout to be exposed */
+	public void setConnReadTimeoutSeconds(int connReadTimeoutSeconds) {
+		this.connReadTimeoutSeconds = connReadTimeoutSeconds;
+	}
+
+	private String getDebugInfo() {
         return "{" +
                 "sendDurationInMillis=" + TimeUnit.MILLISECONDS.convert(sendDurationInNanos.get(), TimeUnit.NANOSECONDS) +
                 ", sendSuccessCount=" + sendSuccessCount +

--- a/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyBatchAppender.java
+++ b/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyBatchAppender.java
@@ -104,6 +104,11 @@ import ch.qos.logback.ext.loggly.io.IoUtils;
  * <td>int</td>
  * <td>Interval of the buffer flush to Loggly API. Default value: <code>3</code>.</td>
  * </tr>
+ * <tr>
+ * <td>connReadTimeoutSeconds</td>
+ * <td>int</td>
+ * <td>How Long the HTTP Connection will wait on reads. Default value: <code>1</code> second.</td>
+ * </tr>
  * </table>
  * Default configuration consumes up to 8 buffers of 1024 Kilobytes (1MB) each, which seems very reasonable even for small JVMs.
  * If logs are discarded, try first to shorten the <code>flushIntervalInSeconds</code> parameter to "2s" or event "1s".

--- a/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyBatchAppender.java
+++ b/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyBatchAppender.java
@@ -435,12 +435,14 @@ public class LogglyBatchAppender<E> extends AbstractLogglyAppender<E> implements
         this.maxBucketSizeInKilobytes = maxBucketSizeInKilobytes;
     }
 
-    /* set method for Logback to allow Connection Read Timeout to be exposed */
-	public void setConnReadTimeoutSeconds(int connReadTimeoutSeconds) {
-		this.connReadTimeoutSeconds = connReadTimeoutSeconds;
+    /**
+     * set method for Logback to allow Connection Read Timeout to be exposed
+     */
+    public void setConnReadTimeoutSeconds(int connReadTimeoutSeconds) {
+        this.connReadTimeoutSeconds = connReadTimeoutSeconds;
 	}
 
-	private String getDebugInfo() {
+    private String getDebugInfo() {
         return "{" +
                 "sendDurationInMillis=" + TimeUnit.MILLISECONDS.convert(sendDurationInNanos.get(), TimeUnit.NANOSECONDS) +
                 ", sendSuccessCount=" + sendSuccessCount +


### PR DESCRIPTION
Default value was 1 second and for Testing over a slow ADSL connection I
was often exceeding this. Kept the default (no config) as 1 sec.