### PR TITLE
Added support to X-Forwarded-for Header

### DIFF
--- a/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyAppender.java
+++ b/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyAppender.java
@@ -18,6 +18,7 @@ package ch.qos.logback.ext.loggly;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
 import java.net.URL;
 
 /**
@@ -53,6 +54,7 @@ public class LogglyAppender<E> extends AbstractLogglyAppender<E> {
             connection.setRequestMethod("POST");
             connection.setDoOutput(true);
             connection.addRequestProperty("Content-Type", this.layout.getContentType());
+			connection.addRequestProperty("X-Forwarded-For", InetAddress.getLocalHost().getHostAddress());
             connection.connect();
             sendAndClose(event, connection.getOutputStream());
             connection.disconnect();

--- a/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyBatchAppender.java
+++ b/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyBatchAppender.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.management.ManagementFactory;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.sql.Timestamp;
@@ -321,6 +322,7 @@ public class LogglyBatchAppender<E> extends AbstractLogglyAppender<E> implements
         conn.setDoOutput(true);
         conn.setDoInput(true);
         conn.setRequestProperty("Content-Type", layout.getContentType() + "; charset=" + charset.name());
+		connection.addRequestProperty("X-Forwarded-For", InetAddress.getLocalHost().getHostAddress());
         conn.setRequestMethod("POST");
         conn.setReadTimeout(getHttpReadTimeoutInMillis());
         return conn;


### PR DESCRIPTION
Sends x-forwarded-for header with host IP to the Loggly which is padded in the http fields in Loggly
