### PR TITLE
changes to bump to logback 1.1.7 and java 1.8

### DIFF
--- a/loggly/src/test/java/ch/qos/logback/ext/loggly/LogglyBatchAppenderTest.java
+++ b/loggly/src/test/java/ch/qos/logback/ext/loggly/LogglyBatchAppenderTest.java
@@ -56,7 +56,7 @@ public class LogglyBatchAppenderTest {
     httpServer = new HttpTestServer(PORT);
     httpServer.start();
     context = new LoggerContext();
-    OnConsoleStatusListener.addNewInstanceToContext(context);
+//    OnConsoleStatusListener.addNewInstanceToContext(context);
   }
 
   /**

--- a/loggly/src/test/java/ch/qos/logback/ext/loggly/LogglySendOnlyWhenMaxBucketsFullTest.java
+++ b/loggly/src/test/java/ch/qos/logback/ext/loggly/LogglySendOnlyWhenMaxBucketsFullTest.java
@@ -62,7 +62,7 @@ public class LogglySendOnlyWhenMaxBucketsFullTest {
   @BeforeClass
   static public void beforeClass() {
     context = new LoggerContext();
-    OnConsoleStatusListener.addNewInstanceToContext(context);
+//    OnConsoleStatusListener.addNewInstanceToContext(context);
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -89,11 +89,11 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <logback.version>1.1.1</logback.version>
+    <logback.version>1.1.7</logback.version>
 
     <!-- JDK properties that can be overridden from the command line
          to build under a different JDKs (continuous integration) -->
-    <jdk.version>1.6</jdk.version>
+    <jdk.version>1.8</jdk.version>
     <maven.compiler.source>${jdk.version}</maven.compiler.source>
     <maven.compiler.target>${jdk.version}</maven.compiler.target>
 


### PR DESCRIPTION
If you choose to merge this,  can you also do a release to maven central ?

BTW java 6 and java 7 are now EOL.    so supporting  java 8 should be minimum for a top of tree.

If others would like to maintain a back rev (java 6) branch I think that might be a valid approach to keeping folks stuck on older java in the fold.
