### PR TITLE
Fix for #45 - remove setter that causes logback warning

### DIFF
--- a/loggly/src/main/java/ch/qos/logback/ext/loggly/AbstractLogglyAppender.java
+++ b/loggly/src/main/java/ch/qos/logback/ext/loggly/AbstractLogglyAppender.java
@@ -191,9 +191,6 @@ public abstract class AbstractLogglyAppender<E> extends UnsynchronizedAppenderBa
         return proxyPort;
     }
 
-    public void setProxyPort(int proxyPort) {
-        this.proxyPort = proxyPort;
-    }
     public void setProxyPort(String proxyPort) {
         if(proxyPort == null || proxyPort.trim().isEmpty()) {
             // handle logback configuration default value like "<proxyPort>${logback.loggly.proxy.port:-}</proxyPort>"


### PR DESCRIPTION
Remove int proxy port setter, as Logback generates warnings because of it (and it was otherwise not used).

Signed-off-by: John Dimeo <dimeo@elderresearch.com>