### PR TITLE
Use PrepForDeferral on ILoggingEvent

### DIFF
--- a/spring/src/main/java/ch/qos/logback/ext/spring/DelegatingLogbackAppender.java
+++ b/spring/src/main/java/ch/qos/logback/ext/spring/DelegatingLogbackAppender.java
@@ -149,6 +149,10 @@ public class DelegatingLogbackAppender extends UnsynchronizedAppenderBase<ILoggi
                         delegate = appender;
                     } else {
                         //Otherwise, if the ApplicationContext is not ready yet, cache this event and wait
+                                                
+                        // make sure MDC and other attributes are captured before deferring
+                        event.prepareForDeferredProcessing();
+                        
                         cache.put(event);
 
                         return;


### PR DESCRIPTION
To avoid losing MDC context ILoggingEvent has a `prepareForDeferredProcessing` that is supposed to be used in an appender that runs asynchronously. JavaDoc: This method should be called prior to serializing an event. It should also be called when using asynchronous or deferred logging. ...