### PR TITLE
Update LogglyBatchAppender description

### DIFF
--- a/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyBatchAppender.java
+++ b/loggly/src/main/java/ch/qos/logback/ext/loggly/LogglyBatchAppender.java
@@ -65,7 +65,7 @@ import ch.qos.logback.ext.loggly.io.IoUtils;
  * <td>endpointUrl</td>
  * <td>String</td>
  * <td>Loggly HTTP API endpoint URL. "<code>inputKey</code>" or <code>endpointUrl</code> is required. Sample:
- * "<code>https://logs.loggly.com/inputs/12345678-90ab-cdef-1234-567890abcdef</code>"</td>
+ * "<code>https://logs.loggly.com/bulk/12345678-90ab-cdef-1234-567890abcdef</code>"</td>
  * </tr>
  * <tr>
  * <td>pattern</td>


### PR DESCRIPTION
With 'inputs' directory it sends logs to Loggly in Batched mode, but only the first log is parsed correctly, other are displayed only in raw message of that first log. In order to send logs in Batched mode, you have to change 'inputs' directory to 'bulk'.

Signed-off-by: Yulian Koval <yulian.koval@gmail.com>